### PR TITLE
Add Mandarin and Mandarin OLED themes

### DIFF
--- a/yaml_files/mandarin.yaml
+++ b/yaml_files/mandarin.yaml
@@ -1,0 +1,29 @@
+# Mandarin Warp Theme
+# Author: mindtnv
+name: Mandarin
+details: "darker"
+accent: "#FF8C00"
+background: "#1a1a1a"
+cursor: "#FFA500"
+foreground: "#e8e8e8"
+selection: "#3d3d3d"
+
+terminal_colors:
+  normal:
+    black:   "#1a1a1a"
+    red:     "#D35100"
+    green:   "#5a9a5a"
+    yellow:  "#FF8C00"
+    blue:    "#5a8ac0"
+    magenta: "#a05a90"
+    cyan:    "#5a9aaa"
+    white:   "#e8e8e8"
+  bright:
+    black:   "#3d3d3d"
+    red:     "#FF6B35"
+    green:   "#7ac07a"
+    yellow:  "#FFA500"
+    blue:    "#7ab0e0"
+    magenta: "#c07ab0"
+    cyan:    "#7ac0d0"
+    white:   "#ffffff"

--- a/yaml_files/mandarin_oled.yaml
+++ b/yaml_files/mandarin_oled.yaml
@@ -1,0 +1,29 @@
+# Mandarin OLED Warp Theme
+# Author: mindtnv
+name: Mandarin OLED
+details: "darker"
+accent: "#F07900"
+background: "#000000"
+cursor: "#F8A145"
+foreground: "#f0f0f0"
+selection: "#151515"
+
+terminal_colors:
+  normal:
+    black:   "#000000"
+    red:     "#D35100"
+    green:   "#5a9a5a"
+    yellow:  "#F07900"
+    blue:    "#5a8ac0"
+    magenta: "#a05a90"
+    cyan:    "#5a9aaa"
+    white:   "#f0f0f0"
+  bright:
+    black:   "#252525"
+    red:     "#FF6B35"
+    green:   "#7ac07a"
+    yellow:  "#F8A145"
+    blue:    "#7ab0e0"
+    magenta: "#c07ab0"
+    cyan:    "#7ac0d0"
+    white:   "#ffffff"


### PR DESCRIPTION
## Summary
- Add **Mandarin** theme - dark theme with classic mandarin orange accent (#FF8C00) and dark gray background (#1a1a1a)
- Add **Mandarin OLED** theme - true black background (#000000) optimized for OLED displays with saturated mandarin orange accent (#F07900)

Both themes feature:
- Warm mandarin orange as the primary accent color
- Neutral color palette with saturated terminal colors
- Designed for use with terminal transparency

## Preview

**Mandarin** - Classic dark with gray background
**Mandarin OLED** - True black for OLED displays

🤖 Generated with [Claude Code](https://claude.ai/code)