### PR TITLE
Fix mac installer + ukiyo themes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -79,7 +79,7 @@ extract_bg_image() {
                 break
             fi
             if echo "$line" | grep -q "path:"; then
-                bg_path=$(echo "$line" | sed "s/.*path:[[:space:]]*['\"]\\?//" | sed "s/['\"].*//")
+                bg_path=$(echo "$line" | sed -E "s/.*path:[[:space:]]*['\"]?//" | sed -E "s/['\"].*//")
                 bg_path=$(echo "$bg_path" | tr -d '[:space:]')
                 break
             fi

--- a/mac_install.zsh
+++ b/mac_install.zsh
@@ -78,7 +78,7 @@ extract_bg_image() {
                 break
             fi
             if echo "$line" | grep -q "path:"; then
-                bg_path=$(echo "$line" | sed "s/.*path:[[:space:]]*['\"]\\?//" | sed "s/['\"].*//" | tr -d '[:space:]')
+                bg_path=$(echo "$line" | sed -E "s/.*path:[[:space:]]*['\"]?//" | sed -E "s/['\"].*//" | tr -d '[:space:]')
                 break
             fi
         fi

--- a/mac_installer.sh
+++ b/mac_installer.sh
@@ -78,7 +78,7 @@ extract_bg_image() {
                 break
             fi
             if echo "$line" | grep -q "path:"; then
-                bg_path=$(echo "$line" | sed "s/.*path:[[:space:]]*['\"]\\?//" | sed "s/['\"].*//" | tr -d '[:space:]')
+                bg_path=$(echo "$line" | sed -E "s/.*path:[[:space:]]*['\"]?//" | sed -E "s/['\"].*//" | tr -d '[:space:]')
                 break
             fi
         fi

--- a/yaml_files/dark_knight.yaml
+++ b/yaml_files/dark_knight.yaml
@@ -7,10 +7,6 @@ accent: "#d26937"
 background: "#0c1014"
 foreground: "#99d1ce"
 
-background_image:
-  path: 'dark_knight.png'
-  opacity: 20
-
 terminal_colors:
   bright:
     black: "#091f2e"

--- a/yaml_files/ethereal_galaxy_dark.yaml
+++ b/yaml_files/ethereal_galaxy_dark.yaml
@@ -7,7 +7,8 @@ background: "#1C1C3F"
 foreground: "#DCDCE0"
 background_image:
   path: 'ethereal_galaxy.png'
-  
+  opacity: 40
+
 terminal_colors:
   normal:
     black: "#1C1C3F"

--- a/yaml_files/neural_nebula_dark.yaml
+++ b/yaml_files/neural_nebula_dark.yaml
@@ -7,7 +7,8 @@ background: "#0F111A"
 foreground: "#ECEFF4"
 background_image:
   path: 'neural_nebula.png'
-  
+  opacity: 40
+
 terminal_colors:
   normal:
     black:   "#2E3440"

--- a/yaml_files/strand_dark.yaml
+++ b/yaml_files/strand_dark.yaml
@@ -7,7 +7,8 @@ background: "#0A120F"
 foreground: "#B4EBC7"
 background_image:
   path: 'dark_strand.png'
-  
+  opacity: 40
+
 terminal_colors:
   normal:
     black: "#0A120F"

--- a/yaml_files/ukiyo_day.yaml
+++ b/yaml_files/ukiyo_day.yaml
@@ -5,6 +5,9 @@ details: "lighter"
 accent: "#3a6f7a"
 background: "#f4f1ea"
 foreground: "#2a2f2e"
+background_image:
+  path: 'ukiyo_day.png'
+  opacity: 50
 
 terminal_colors:
   normal:

--- a/yaml_files/ukiyo_night.yaml
+++ b/yaml_files/ukiyo_night.yaml
@@ -7,7 +7,7 @@ background: "#0f1b1e"
 foreground: "#d8e1dc"
 background_image:
   path: 'ukiyo_night.png'
-  opacity: 20
+  opacity: 50
 
 terminal_colors:
   normal:


### PR DESCRIPTION
Hey, ran into a few issues installing on macOS:

The bg image regex in mac_install.zsh / mac_installer.sh uses \? which is GNU sed only — on BSD sed (mac default) it doesn't strip the prefix and extract_bg_image returns the literal "path:". Result is every theme with a background falls back to a 1x1 PNG written as ~/.warp/themes/path:. Switched to sed -E with ['"]?, also updated install.sh to match.

While I was in there:
- ukiyo_day.yaml was missing a background_image block (asset was already in backgrounds/)
- ukiyo_night.yaml opacity 20 felt too dim, bumped to 50
- dark_knight.yaml referenced dark_knight.png which doesn't exist in backgrounds/, dropped the block
- ethereal_galaxy_dark / neural_nebula_dark / strand_dark each had a path: line with no opacity, added opacity: 40

Tested by running the patched installer locally against this branch — all 53 themes install with their backgrounds, no path: file created.